### PR TITLE
Dirty form navigation blocking, persistance expense list filter, device id cookie

### DIFF
--- a/client/routeTree.gen.ts
+++ b/client/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SignupIndexRouteImport } from './routes/signup/index'
 import { Route as SignupVerifyRouteImport } from './routes/signup/verify'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
+import { Route as AuthenticatedExpensesRouteRouteImport } from './routes/_authenticated/expenses/route'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedExpensesIndexRouteImport } from './routes/_authenticated/expenses/index'
 import { Route as AuthenticatedSettingsManageSubjectsRouteImport } from './routes/_authenticated/settings/manage-subjects'
@@ -67,6 +68,12 @@ const AuthenticatedDashboardRoute = AuthenticatedDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedExpensesRouteRoute =
+  AuthenticatedExpensesRouteRouteImport.update({
+    id: '/expenses',
+    path: '/expenses',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedSettingsIndexRoute =
   AuthenticatedSettingsIndexRouteImport.update({
     id: '/settings/',
@@ -75,9 +82,9 @@ const AuthenticatedSettingsIndexRoute =
   } as any)
 const AuthenticatedExpensesIndexRoute =
   AuthenticatedExpensesIndexRouteImport.update({
-    id: '/expenses/',
-    path: '/expenses/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedExpensesRouteRoute,
   } as any)
 const AuthenticatedSettingsManageSubjectsRoute =
   AuthenticatedSettingsManageSubjectsRouteImport.update({
@@ -93,9 +100,9 @@ const AuthenticatedSettingsElevatedRoute =
   } as any)
 const AuthenticatedExpensesExpenseIdRouteRoute =
   AuthenticatedExpensesExpenseIdRouteRouteImport.update({
-    id: '/expenses/$expenseId',
-    path: '/expenses/$expenseId',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/$expenseId',
+    path: '/$expenseId',
+    getParentRoute: () => AuthenticatedExpensesRouteRoute,
   } as any)
 const AuthenticatedExpensesExpenseIdIndexRoute =
   AuthenticatedExpensesExpenseIdIndexRouteImport.update({
@@ -133,6 +140,7 @@ export interface FileRoutesByFullPath {
   '/signup': typeof SignupRouteRouteWithChildren
   '/signin': typeof SigninRoute
   '/verify': typeof VerifyRoute
+  '/expenses': typeof AuthenticatedExpensesRouteRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/signup/verify': typeof SignupVerifyRoute
   '/signup/': typeof SignupIndexRoute
@@ -170,6 +178,7 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/signin': typeof SigninRoute
   '/verify': typeof VerifyRoute
+  '/_authenticated/expenses': typeof AuthenticatedExpensesRouteRouteWithChildren
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/signup/verify': typeof SignupVerifyRoute
   '/signup/': typeof SignupIndexRoute
@@ -191,6 +200,7 @@ export interface FileRouteTypes {
     | '/signup'
     | '/signin'
     | '/verify'
+    | '/expenses'
     | '/dashboard'
     | '/signup/verify'
     | '/signup/'
@@ -227,6 +237,7 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/signin'
     | '/verify'
+    | '/_authenticated/expenses'
     | '/_authenticated/dashboard'
     | '/signup/verify'
     | '/signup/'
@@ -308,6 +319,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDashboardRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/expenses': {
+      id: '/_authenticated/expenses'
+      path: '/expenses'
+      fullPath: '/expenses'
+      preLoaderRoute: typeof AuthenticatedExpensesRouteRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/settings/': {
       id: '/_authenticated/settings/'
       path: '/settings'
@@ -317,10 +335,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/expenses/': {
       id: '/_authenticated/expenses/'
-      path: '/expenses'
+      path: '/'
       fullPath: '/expenses/'
       preLoaderRoute: typeof AuthenticatedExpensesIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedExpensesRouteRoute
     }
     '/_authenticated/settings/manage-subjects': {
       id: '/_authenticated/settings/manage-subjects'
@@ -338,10 +356,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/expenses/$expenseId': {
       id: '/_authenticated/expenses/$expenseId'
-      path: '/expenses/$expenseId'
+      path: '/$expenseId'
       fullPath: '/expenses/$expenseId'
       preLoaderRoute: typeof AuthenticatedExpensesExpenseIdRouteRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedExpensesRouteRoute
     }
     '/_authenticated/expenses/$expenseId/': {
       id: '/_authenticated/expenses/$expenseId/'
@@ -419,6 +437,23 @@ const AuthenticatedExpensesExpenseIdRouteRouteWithChildren =
     AuthenticatedExpensesExpenseIdRouteRouteChildren,
   )
 
+interface AuthenticatedExpensesRouteRouteChildren {
+  AuthenticatedExpensesExpenseIdRouteRoute: typeof AuthenticatedExpensesExpenseIdRouteRouteWithChildren
+  AuthenticatedExpensesIndexRoute: typeof AuthenticatedExpensesIndexRoute
+}
+
+const AuthenticatedExpensesRouteRouteChildren: AuthenticatedExpensesRouteRouteChildren =
+  {
+    AuthenticatedExpensesExpenseIdRouteRoute:
+      AuthenticatedExpensesExpenseIdRouteRouteWithChildren,
+    AuthenticatedExpensesIndexRoute: AuthenticatedExpensesIndexRoute,
+  }
+
+const AuthenticatedExpensesRouteRouteWithChildren =
+  AuthenticatedExpensesRouteRoute._addFileChildren(
+    AuthenticatedExpensesRouteRouteChildren,
+  )
+
 interface AuthenticatedSettingsElevatedRouteChildren {
   AuthenticatedSettingsElevatedPasskeyRoute: typeof AuthenticatedSettingsElevatedPasskeyRoute
 }
@@ -435,23 +470,20 @@ const AuthenticatedSettingsElevatedRouteWithChildren =
   )
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedExpensesRouteRoute: typeof AuthenticatedExpensesRouteRouteWithChildren
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
-  AuthenticatedExpensesExpenseIdRouteRoute: typeof AuthenticatedExpensesExpenseIdRouteRouteWithChildren
   AuthenticatedSettingsElevatedRoute: typeof AuthenticatedSettingsElevatedRouteWithChildren
   AuthenticatedSettingsManageSubjectsRoute: typeof AuthenticatedSettingsManageSubjectsRoute
-  AuthenticatedExpensesIndexRoute: typeof AuthenticatedExpensesIndexRoute
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedExpensesRouteRoute: AuthenticatedExpensesRouteRouteWithChildren,
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
-  AuthenticatedExpensesExpenseIdRouteRoute:
-    AuthenticatedExpensesExpenseIdRouteRouteWithChildren,
   AuthenticatedSettingsElevatedRoute:
     AuthenticatedSettingsElevatedRouteWithChildren,
   AuthenticatedSettingsManageSubjectsRoute:
     AuthenticatedSettingsManageSubjectsRoute,
-  AuthenticatedExpensesIndexRoute: AuthenticatedExpensesIndexRoute,
   AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
 }
 

--- a/client/routes/_authenticated/expenses/$expenseId/-common/DirtyFormBlockModel.tsx
+++ b/client/routes/_authenticated/expenses/$expenseId/-common/DirtyFormBlockModel.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useRef } from 'react';
+import { useExpenseForm } from '.';
+import { useBlocker } from '@tanstack/react-router';
+
+type DirtyFormBlockModelProp = {
+  mainRouteId: string;
+};
+
+export function DirtyFormBlockModel({ mainRouteId }: DirtyFormBlockModelProp) {
+  const form = useExpenseForm();
+  const confirmationModelRef = useRef<HTMLDialogElement>(null);
+
+  const { proceed } = useBlocker({
+    withResolver: true,
+    enableBeforeUnload: true,
+    shouldBlockFn: ({ next }) => {
+      if (!form.state.isDirty || form.state.isSubmitSuccessful) return false;
+      const isNavigateToChild = next.routeId.startsWith(mainRouteId);
+      const isNextViewPage = next.routeId.endsWith('view');
+      const shouldBlock = !isNavigateToChild || isNextViewPage;
+      if (shouldBlock) {
+        confirmationModelRef.current?.showModal();
+      }
+      return shouldBlock;
+    },
+  });
+
+  return (
+    <dialog className='modal' ref={confirmationModelRef}>
+      <div className='modal-box'>
+        <h3 className='text-lg font-bold'>You have unsaved changes. Are you sure you want to leave this page?</h3>
+        <p>Your changes will be lost.</p>
+        <div className='modal-action'>
+          <button className='btn btn-ghost' onClick={() => confirmationModelRef.current?.close()}>
+            Stay Here
+          </button>
+          <button
+            className='btn btn-error'
+            onClick={() => (form.reset(), confirmationModelRef.current?.close(), proceed?.())}
+          >
+            Leave Page
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/client/routes/_authenticated/expenses/$expenseId/index.tsx
+++ b/client/routes/_authenticated/expenses/$expenseId/index.tsx
@@ -84,12 +84,7 @@ function RouteComponent() {
           Cancel
         </Link>
       ) : (
-        <Link
-          className='btn col-span-4 w-full'
-          to='/expenses/$expenseId/view'
-          params={{ expenseId }}
-          onClick={() => form.reset()}
-        >
+        <Link className='btn col-span-4 w-full' to='/expenses/$expenseId/view' params={{ expenseId }}>
           Cancel
         </Link>
       )}

--- a/client/routes/_authenticated/expenses/$expenseId/route.tsx
+++ b/client/routes/_authenticated/expenses/$expenseId/route.tsx
@@ -15,6 +15,7 @@ import type { DeepKeys } from '@tanstack/react-form';
 import { GST_NAME, SERVICE_CHARGE_NAME } from '#server/lib/expenseHelper';
 import { ShopDetailPicker, useShopDetailPickerRef } from './-common/ShopDetailPicker';
 import { ShopNameMallPicker, useShopNameMallPickerRef } from './-common/ShopPicker';
+import { DirtyFormBlockModel } from './-common/DirtyFormBlockModel';
 
 export const Route = createFileRoute('/_authenticated/expenses/$expenseId')({
   component: RouteComponent,
@@ -141,7 +142,7 @@ function RouteComponent() {
 
   useEffect(() => {
     if (isCreate) {
-      form.setFieldValue('billedAt', new Date());
+      form.setFieldValue('billedAt', new Date(), { dontUpdateMeta: true });
     }
   }, [isCreate, form]);
 
@@ -196,6 +197,7 @@ function RouteComponent() {
             form.setFieldValue('ui.shopDetailSource', 'autocomplete');
           }}
         />
+        <DirtyFormBlockModel mainRouteId={Route.id} />
       </form.AppForm>
     </div>
   );

--- a/client/routes/_authenticated/expenses/-context.tsx
+++ b/client/routes/_authenticated/expenses/-context.tsx
@@ -1,0 +1,33 @@
+import { formOptions } from '@tanstack/react-form';
+import { createContext, useContext, useRef, type ReactNode, type RefObject } from 'react';
+import { type Option } from '#components/Form';
+
+export const expenseListOptions = formOptions({
+  defaultValues: {
+    showDeleted: false,
+    accountIds: [] as Option[],
+    categoryIds: [] as Option[],
+  },
+});
+
+export type ExpenseListOptions = (typeof expenseListOptions)['defaultValues'];
+
+type ExpenseListContextType = {
+  listOptionsRef: RefObject<ExpenseListOptions>;
+};
+
+const ExpenseContext = createContext<ExpenseListContextType | undefined>(undefined);
+
+export const ExpenseContextProvider = ({ children }: { children: ReactNode }) => {
+  const listOptionsRef = useRef<ExpenseListOptions>(expenseListOptions.defaultValues);
+
+  return <ExpenseContext.Provider value={{ listOptionsRef }}>{children}</ExpenseContext.Provider>;
+};
+
+export const useExpenseContext = () => {
+  const context = useContext(ExpenseContext);
+  if (!context) {
+    throw new Error('useExpenseListOptions must be used within ExpenseListOptionsProvider');
+  }
+  return context;
+};

--- a/client/routes/_authenticated/expenses/index.tsx
+++ b/client/routes/_authenticated/expenses/index.tsx
@@ -8,8 +8,8 @@ import { abbreviatedMonthValues } from '#client/constants';
 import { PageHeader } from '#components/PageHeader';
 import { currencyNumberFormat } from '#client/utils';
 import { useMemo } from 'react';
-import { formOptions } from '@tanstack/react-form';
-import { useAppForm, type Option } from '#components/Form';
+import { useAppForm } from '#components/Form';
+import { expenseListOptions, useExpenseContext, type ExpenseListOptions } from './-context';
 
 export const Route = createFileRoute('/_authenticated/expenses/')({
   pendingComponent: RoutePendingComponent,
@@ -126,15 +126,6 @@ function RoutePendingComponent() {
 }
 
 const unspecifiedOption = { label: '(Unspecified)', value: '--unspecified--' };
-const expenseListOptions = formOptions({
-  defaultValues: {
-    showDeleted: false,
-    accountIds: [] as Option[],
-    categoryIds: [] as Option[],
-  },
-});
-
-type ExpenseListOptions = (typeof expenseListOptions)['defaultValues'];
 
 function FilterAndGroupExpenses(expenses: RouterOutputs['expense']['list']['expenses'], options: ExpenseListOptions) {
   const { showDeleted, accountIds, categoryIds } = options;
@@ -200,10 +191,14 @@ function NoRecordsFound({ dueToFilter }: { dueToFilter?: boolean }) {
 
 function RouteComponent() {
   const loaderDeps = Route.useLoaderDeps();
+  const { listOptionsRef } = useExpenseContext();
   const {
     data: { expenses },
   } = useSuspenseQuery(trpc.expense.list.queryOptions(loaderDeps));
-  const form = useAppForm({ ...expenseListOptions });
+  const form = useAppForm({
+    defaultValues: listOptionsRef.current,
+    listeners: { onChange: ({ formApi }) => (listOptionsRef.current = formApi.state.values) },
+  });
   const { data: options } = useSuspenseQuery(trpc.expense.loadOptions.queryOptions());
   const accountOptions = useMemo(() => [unspecifiedOption, ...options.accountOptions], [options]);
   const categoryOptions = useMemo(() => [unspecifiedOption, ...options.categoryOptions], [options]);

--- a/client/routes/_authenticated/expenses/route.tsx
+++ b/client/routes/_authenticated/expenses/route.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { ExpenseContextProvider } from './-context';
+
+export const Route = createFileRoute('/_authenticated/expenses')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return (
+    <ExpenseContextProvider>
+      <Outlet />
+    </ExpenseContextProvider>
+  );
+}

--- a/db/migrations/d1-preprod/003_V002_1.sql
+++ b/db/migrations/d1-preprod/003_V002_1.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `user_devices` (
+	`device_id` text(21) NOT NULL,
+	`user_id` text(21) NOT NULL,
+	`last_used_at` integer NOT NULL,
+	`nickname` text,
+	CONSTRAINT `user_devices_pk` PRIMARY KEY(`device_id`, `user_id`)
+);
+
+DELETE FROM `login_attempts`;
+ALTER TABLE `login_attempts` ADD `device_id` text(21) NOT NULL;
+DELETE FROM `sessions`;
+ALTER TABLE `sessions` ADD `device_id` text(21) NOT NULL;
+ALTER TABLE `sessions` DROP COLUMN `version`;
+ALTER TABLE `sessions` DROP COLUMN `updated_at`;
+ALTER TABLE `sessions` DROP COLUMN `last_used_at`;

--- a/db/migrations/d1-prod/003_V002_1.sql
+++ b/db/migrations/d1-prod/003_V002_1.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `user_devices` (
+	`device_id` text(21) NOT NULL,
+	`user_id` text(21) NOT NULL,
+	`last_used_at` integer NOT NULL,
+	`nickname` text,
+	CONSTRAINT `user_devices_pk` PRIMARY KEY(`device_id`, `user_id`)
+);
+
+DELETE FROM `login_attempts`;
+ALTER TABLE `login_attempts` ADD `device_id` text(21) NOT NULL;
+DELETE FROM `sessions`;
+ALTER TABLE `sessions` ADD `device_id` text(21) NOT NULL;
+ALTER TABLE `sessions` DROP COLUMN `version`;
+ALTER TABLE `sessions` DROP COLUMN `updated_at`;
+ALTER TABLE `sessions` DROP COLUMN `last_used_at`;

--- a/db/migrations/drizzle/20260531131040_V002_1/migration.sql
+++ b/db/migrations/drizzle/20260531131040_V002_1/migration.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `user_devices` (
+	`device_id` text(21) NOT NULL,
+	`user_id` text(21) NOT NULL,
+	`last_used_at` integer NOT NULL,
+	`nickname` text,
+	CONSTRAINT `user_devices_pk` PRIMARY KEY(`device_id`, `user_id`)
+);
+
+ALTER TABLE `login_attempts` ADD `device_id` text(21) NOT NULL;
+ALTER TABLE `sessions` ADD `device_id` text(21) NOT NULL;
+ALTER TABLE `sessions` DROP COLUMN `version`;
+ALTER TABLE `sessions` DROP COLUMN `updated_at`;
+ALTER TABLE `sessions` DROP COLUMN `last_used_at`;

--- a/db/migrations/drizzle/20260531131040_V002_1/snapshot.json
+++ b/db/migrations/drizzle/20260531131040_V002_1/snapshot.json
@@ -1,0 +1,2204 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "358c0e1f-41ea-4c58-8bf9-e29098f6cc8f",
+  "prevIds": [
+    "07279aa4-f3dc-48ec-9469-fd565e18d678"
+  ],
+  "ddl": [
+    {
+      "name": "accounts",
+      "entityType": "tables"
+    },
+    {
+      "name": "categories",
+      "entityType": "tables"
+    },
+    {
+      "name": "email_codes",
+      "entityType": "tables"
+    },
+    {
+      "name": "expense_adjustments",
+      "entityType": "tables"
+    },
+    {
+      "name": "expense_items",
+      "entityType": "tables"
+    },
+    {
+      "name": "expense_refunds",
+      "entityType": "tables"
+    },
+    {
+      "name": "expenses_texts",
+      "entityType": "tables"
+    },
+    {
+      "name": "expenses",
+      "entityType": "tables"
+    },
+    {
+      "name": "login_attempts",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkeys",
+      "entityType": "tables"
+    },
+    {
+      "name": "search",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "texts_chunks",
+      "entityType": "tables"
+    },
+    {
+      "name": "texts_contexts",
+      "entityType": "tables"
+    },
+    {
+      "name": "texts",
+      "entityType": "tables"
+    },
+    {
+      "name": "user_devices",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_deleted",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_deleted",
+      "entityType": "columns",
+      "table": "categories"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "text(6)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "purpose",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "valid_until",
+      "entityType": "columns",
+      "table": "email_codes"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_cents",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_bps",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_id",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_item_id",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_deleted",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_inferable",
+      "entityType": "columns",
+      "table": "expense_adjustments"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "quantity",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "price_cents",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_id",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category_id",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_refund_id",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_deleted",
+      "entityType": "columns",
+      "table": "expense_items"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_id",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_item_id",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "expected_amount_cents",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "actual_amount_cents",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "confirmed_at",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_deleted",
+      "entityType": "columns",
+      "table": "expense_refunds"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expense_id",
+      "entityType": "columns",
+      "table": "expenses_texts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text_hash",
+      "entityType": "columns",
+      "table": "expenses_texts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "table": "expenses_texts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "amount_cents",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "specified_amount_cents",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "billed_at",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category_id",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "latitude",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "longitude",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "geo_accuracy",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "box_id",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shop_name",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shop_mall",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "additional_service_charge_percent",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_gst_excluded",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "is_deleted",
+      "entityType": "columns",
+      "table": "expenses"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "attempted_for_id",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_success",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "asn",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "city",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "region",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text(2)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "country",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text(3)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "colo",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "login_attempts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "blob",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "nickname",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chunk",
+      "entityType": "columns",
+      "table": "search"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "search"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "search"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "search"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "search"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "context",
+      "entityType": "columns",
+      "table": "search"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "login_attempt_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "texts_chunks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chunk",
+      "entityType": "columns",
+      "table": "texts_chunks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text_hash",
+      "entityType": "columns",
+      "table": "texts_chunks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text_hash",
+      "entityType": "columns",
+      "table": "texts_contexts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ctx_text_hash",
+      "entityType": "columns",
+      "table": "texts_contexts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text_hash",
+      "entityType": "columns",
+      "table": "texts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "texts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "texts"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "table": "user_devices"
+    },
+    {
+      "type": "text(21)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "user_devices"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "table": "user_devices"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "nickname",
+      "entityType": "columns",
+      "table": "user_devices"
+    },
+    {
+      "type": "text(21)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text COLLATE NOCASE",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "blob",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pass_salt",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "blob",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pass_digest",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "failed_attempts",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "released_after",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "text_hash"
+      ],
+      "tableTo": "texts",
+      "columnsTo": [
+        "text_hash"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_expenses_texts_text_hash_texts_text_hash_fk",
+      "entityType": "fks",
+      "table": "expenses_texts"
+    },
+    {
+      "columns": [
+        "text_hash"
+      ],
+      "tableTo": "texts",
+      "columnsTo": [
+        "text_hash"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_texts_chunks_text_hash_texts_text_hash_fk",
+      "entityType": "fks",
+      "table": "texts_chunks"
+    },
+    {
+      "columns": [
+        "text_hash"
+      ],
+      "tableTo": "texts",
+      "columnsTo": [
+        "text_hash"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_texts_contexts_text_hash_texts_text_hash_fk",
+      "entityType": "fks",
+      "table": "texts_contexts"
+    },
+    {
+      "columns": [
+        "ctx_text_hash"
+      ],
+      "tableTo": "texts",
+      "columnsTo": [
+        "text_hash"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_texts_contexts_ctx_text_hash_texts_text_hash_fk",
+      "entityType": "fks",
+      "table": "texts_contexts"
+    },
+    {
+      "columns": [
+        "text_hash",
+        "source_id"
+      ],
+      "nameExplicit": false,
+      "name": "expenses_texts_pk",
+      "entityType": "pks",
+      "table": "expenses_texts"
+    },
+    {
+      "columns": [
+        "chunk",
+        "text",
+        "type",
+        "user_id",
+        "context"
+      ],
+      "nameExplicit": false,
+      "name": "search_pk",
+      "entityType": "pks",
+      "table": "search"
+    },
+    {
+      "columns": [
+        "text_hash",
+        "chunk"
+      ],
+      "nameExplicit": false,
+      "name": "texts_chunks_pk",
+      "entityType": "pks",
+      "table": "texts_chunks"
+    },
+    {
+      "columns": [
+        "text_hash",
+        "ctx_text_hash"
+      ],
+      "nameExplicit": false,
+      "name": "texts_contexts_pk",
+      "entityType": "pks",
+      "table": "texts_contexts"
+    },
+    {
+      "columns": [
+        "device_id",
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_devices_pk",
+      "entityType": "pks",
+      "table": "user_devices"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pk",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "categories_pk",
+      "table": "categories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "email_codes_pk",
+      "table": "email_codes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "expense_adjustments_pk",
+      "table": "expense_adjustments",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "expense_items_pk",
+      "table": "expense_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "expense_refunds_pk",
+      "table": "expense_refunds",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "expenses_pk",
+      "table": "expenses",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "login_attempts_pk",
+      "table": "login_attempts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "passkeys_pk",
+      "table": "passkeys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "text_hash"
+      ],
+      "nameExplicit": false,
+      "name": "texts_pk",
+      "table": "texts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "sequence",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_accounts_user_seq",
+      "entityType": "indexes",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "sequence",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_categories_user_seq",
+      "entityType": "indexes",
+      "table": "categories"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_email_codes_code",
+      "entityType": "indexes",
+      "table": "email_codes"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        },
+        {
+          "value": "valid_until",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_email_codes_email_valid_until",
+      "entityType": "indexes",
+      "table": "email_codes"
+    },
+    {
+      "columns": [
+        {
+          "value": "expense_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expense_adjustments_expense_id",
+      "entityType": "indexes",
+      "table": "expense_adjustments"
+    },
+    {
+      "columns": [
+        {
+          "value": "expense_id",
+          "isExpression": false
+        },
+        {
+          "value": "name",
+          "isExpression": false
+        },
+        {
+          "value": "rate_bps",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": "\"expense_adjustments\".\"is_inferable\" = 1",
+      "origin": "manual",
+      "name": "idx_expense_adjustments_inferrable",
+      "entityType": "indexes",
+      "table": "expense_adjustments"
+    },
+    {
+      "columns": [
+        {
+          "value": "expense_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expense_items_expense_id",
+      "entityType": "indexes",
+      "table": "expense_items"
+    },
+    {
+      "columns": [
+        {
+          "value": "expense_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expense_refund_expense_id",
+      "entityType": "indexes",
+      "table": "expense_refunds"
+    },
+    {
+      "columns": [
+        {
+          "value": "expense_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expense_refund_expense_item_id",
+      "entityType": "indexes",
+      "table": "expense_refunds"
+    },
+    {
+      "columns": [
+        {
+          "value": "source",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expense_refund_source",
+      "entityType": "indexes",
+      "table": "expense_refunds"
+    },
+    {
+      "columns": [
+        {
+          "value": "source_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expenses_texts_sourceId",
+      "entityType": "indexes",
+      "table": "expenses_texts"
+    },
+    {
+      "columns": [
+        {
+          "value": "text_hash",
+          "isExpression": false
+        },
+        {
+          "value": "expense_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_textHash_expenseId",
+      "entityType": "indexes",
+      "table": "expenses_texts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "box_id",
+          "isExpression": false
+        },
+        {
+          "value": "shop_name",
+          "isExpression": false
+        },
+        {
+          "value": "shop_mall",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": "(\"expenses\".\"shop_name\" is not null)",
+      "origin": "manual",
+      "name": "idx_expenses_partial_user_box_shop",
+      "entityType": "indexes",
+      "table": "expenses"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "account_id",
+          "isExpression": false
+        },
+        {
+          "value": "category_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expenses_id_account_category",
+      "entityType": "indexes",
+      "table": "expenses"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "billed_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_expenses_user_billedAt",
+      "entityType": "indexes",
+      "table": "expenses"
+    },
+    {
+      "columns": [
+        {
+          "value": "ip",
+          "isExpression": false
+        },
+        {
+          "value": "timestamp",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_login_attempts_ip_time",
+      "entityType": "indexes",
+      "table": "login_attempts"
+    },
+    {
+      "columns": [
+        {
+          "value": "attempted_for_id",
+          "isExpression": false
+        },
+        {
+          "value": "timestamp",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_login_attempts_user_time",
+      "entityType": "indexes",
+      "table": "login_attempts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_passkeys_user_id",
+      "entityType": "indexes",
+      "table": "passkeys"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "type",
+          "isExpression": false
+        },
+        {
+          "value": "chunk",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_search_chunk",
+      "entityType": "indexes",
+      "table": "search"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "type",
+          "isExpression": false
+        },
+        {
+          "value": "context",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_search_context",
+      "entityType": "indexes",
+      "table": "search"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sessions_token_expires",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sessions_user_expires",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "chunk",
+          "isExpression": false
+        },
+        {
+          "value": "text_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_user_chunks",
+      "entityType": "indexes",
+      "table": "texts_chunks"
+    },
+    {
+      "columns": [
+        {
+          "value": "ctx_text_hash",
+          "isExpression": false
+        },
+        {
+          "value": "text_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_texts_contexts_ctxTextHash_textHash",
+      "entityType": "indexes",
+      "table": "texts_contexts"
+    },
+    {
+      "columns": [
+        "user_id",
+        "text"
+      ],
+      "nameExplicit": true,
+      "name": "uq_texts_userId",
+      "entityType": "uniques",
+      "table": "texts"
+    },
+    {
+      "columns": [
+        "name"
+      ],
+      "nameExplicit": false,
+      "name": "users_name_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -106,7 +106,6 @@ export const passkeysTable = sqliteTable(
     backedUp: boolean().notNull(),
     transports: text({ mode: 'json' }).notNull().$type<AuthenticatorTransportFuture[]>().default([]),
     nickname: text(),
-    deviceId: nullableIdColumn(),
   },
   t => [index('idx_passkeys_user_id').on(t.userId)],
 );
@@ -114,12 +113,12 @@ export const passkeysTable = sqliteTable(
 export const userDevicesTable = sqliteTable(
   'user_devices',
   {
-    id: idColumn(),
+    deviceId: idColumn(),
     userId: idColumn(),
     lastUsedAt: dateColumn(),
     nickname: text(),
   },
-  t => [primaryKey({ columns: [t.id, t.userId] })],
+  t => [primaryKey({ columns: [t.deviceId, t.userId] })],
 );
 
 export const sessionsTable = sqliteTable(

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -65,6 +65,7 @@ export const loginAttemptsTable = sqliteTable(
     timestamp: createdAtColumn(),
     attemptedForId: nullableIdColumn(),
     isSuccess: integer({ mode: 'boolean' }).notNull(),
+    deviceId: idColumn(),
 
     ip: text().notNull(),
     asn: integer(),
@@ -105,8 +106,20 @@ export const passkeysTable = sqliteTable(
     backedUp: boolean().notNull(),
     transports: text({ mode: 'json' }).notNull().$type<AuthenticatorTransportFuture[]>().default([]),
     nickname: text(),
+    deviceId: nullableIdColumn(),
   },
   t => [index('idx_passkeys_user_id').on(t.userId)],
+);
+
+export const userDevicesTable = sqliteTable(
+  'user_devices',
+  {
+    id: idColumn(),
+    userId: idColumn(),
+    lastUsedAt: dateColumn(),
+    nickname: text(),
+  },
+  t => [primaryKey({ columns: [t.id, t.userId] })],
 );
 
 export const sessionsTable = sqliteTable(
@@ -115,7 +128,7 @@ export const sessionsTable = sqliteTable(
     ...baseColumns(),
     token: idColumn(),
     userId: idColumn(),
-    lastUsedAt: dateColumn(),
+    deviceId: idColumn(),
     expiresAt: dateColumn(),
     loginAttemptId: idColumn(),
   },

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -124,7 +124,8 @@ export const userDevicesTable = sqliteTable(
 export const sessionsTable = sqliteTable(
   'sessions',
   {
-    ...baseColumns(),
+    id: pkIdColumn(),
+    createdAt: createdAtColumn(),
     token: idColumn(),
     userId: idColumn(),
     deviceId: idColumn(),

--- a/server/lib/sessions.ts
+++ b/server/lib/sessions.ts
@@ -47,6 +47,7 @@ async function createAndSaveToken(
   resHeaders: CookieHeaders,
   userId: string,
   loginAttemptId: string,
+  deviceId: string,
 ) {
   const tokenParam = generateTokenParam(env);
   const { token, expiresAt } = tokenParam;
@@ -55,8 +56,8 @@ async function createAndSaveToken(
     token,
     expiresAt,
     userId,
-    lastUsedAt: new Date(),
     loginAttemptId,
+    deviceId,
   });
   setTokenCookie(env, resHeaders, tokenParam);
 }
@@ -87,6 +88,7 @@ async function saveLoginAttempt(ctx: Context, isSuccess: boolean, attemptedForId
     userAgent,
     isSuccess,
     attemptedForId,
+    deviceId: ctx.deviceId,
   };
 
   const cfKeys = ['asn', 'city', 'region', 'country', 'colo'];
@@ -117,7 +119,10 @@ async function create(ctx: Context, user: { id: string; name: string; email: str
     userAgent ?? 'unknown',
   ).addRecipient(user.email, user.name);
 
-  await Promise.all([createAndSaveToken(db, env, resHeaders, user.id, loginAttempt.id), alertEmail.send(ctx)]);
+  await Promise.all([
+    createAndSaveToken(db, env, resHeaders, user.id, loginAttempt.id, ctx.deviceId),
+    alertEmail.send(ctx),
+  ]);
 }
 
 async function revoke(ctx: ProtectedContext, otherSessionId?: string) {
@@ -181,6 +186,7 @@ async function check(
 
   if (!authToken) {
     return {
+      deviceId,
       isAuthenticated: false as const,
       authFailureReason: 'Missing token',
     };
@@ -211,6 +217,7 @@ async function check(
   if (!session) {
     resHeaders.deleteCookie(env.TOKEN_COOKIE_NAME);
     return {
+      deviceId,
       isAuthenticated: false as const,
       authFailureReason: 'Unable to find token',
     };
@@ -220,7 +227,7 @@ async function check(
 
   // if the token is older then 2 days, refresh it
   if (differenceInDays(new Date(), session.createdAt) > 2) {
-    await createAndSaveToken(db, env, resHeaders, userId, session.loginAttempt.id);
+    await createAndSaveToken(db, env, resHeaders, userId, session.loginAttempt.id, deviceId);
     await revokeToken(db, userId, session.id, true);
   }
 
@@ -232,6 +239,7 @@ async function check(
   const isAllowElevated = differenceInMinutes(new Date(), session.loginAttempt.timestamp) < 5;
 
   return {
+    deviceId,
     isCsrfValid,
     isAuthenticated: true as const,
     session,

--- a/server/lib/sessions.ts
+++ b/server/lib/sessions.ts
@@ -1,15 +1,18 @@
 import type { Context, ProtectedContext } from './trpc';
-import { addDays } from 'date-fns/addDays';
 import { and, eq, gt } from 'drizzle-orm';
-import { differenceInDays } from 'date-fns/differenceInDays';
-import { addMinutes } from 'date-fns/addMinutes';
 import { UAParser } from 'ua-parser-js';
 import type { AppDatabase } from './db';
 import type { CookieHeaders } from './CookieHeaders';
-import { differenceInMinutes } from 'date-fns';
+import { differenceInMinutes, addMinutes, differenceInDays, addDays } from 'date-fns';
 import { loginAttemptsTable, sessionsTable, usersTable } from '../../db/schema';
 import { signInAlertEmail } from './email';
 import { nanoid } from 'nanoid';
+import { millisecondsInDay, secondsInDay } from 'date-fns/constants';
+
+export const COOKIE_NAME = {
+  CSRF: 'csrf',
+  DEVICE: 'device',
+} as const;
 
 export function generateTokenParam(env: Env) {
   const DAYS_TOKEN_EXPIRE = env.TOKEN_EXPIRE_DAYS;
@@ -125,6 +128,34 @@ async function revoke(ctx: ProtectedContext, otherSessionId?: string) {
   await revokeToken(db, userId, otherSessionId ?? session.id);
 }
 
+function processDeviceToken(deviceCookieValue: string | undefined, resHeaders: CookieHeaders) {
+  const currentDay = Math.trunc(Date.now() / millisecondsInDay);
+  let deviceId: string | undefined;
+  let creationDaystamp: string | undefined;
+  if (deviceCookieValue) {
+    [deviceId, creationDaystamp] = deviceCookieValue.split('|');
+    if (deviceId && deviceId.length === 21 && creationDaystamp) {
+      const creationDay = parseInt(creationDaystamp);
+      if (Number.isFinite(creationDay)) {
+        const age = currentDay - creationDay;
+        if (age < 200) return { deviceId };
+      } else deviceId = undefined;
+    } else deviceId = undefined;
+  }
+  deviceId ??= nanoid();
+  creationDaystamp = currentDay.toString();
+  const cookieValue = `${deviceId}|${creationDaystamp}`;
+  resHeaders.setCookie(COOKIE_NAME.DEVICE, cookieValue, {
+    secure: !import.meta.env.DEV,
+    httpOnly: true,
+    path: '/',
+    maxAge: 400 * secondsInDay,
+    sameSite: 'Strict',
+  });
+
+  return { deviceId };
+}
+
 async function check(
   db: AppDatabase,
   req: Request,
@@ -133,11 +164,13 @@ async function check(
   reqCookie: Record<string, string | undefined>,
 ) {
   const authToken = reqCookie[env.TOKEN_COOKIE_NAME];
-  const csrfToken = reqCookie['csrf'];
+  const csrfToken = reqCookie[COOKIE_NAME.CSRF];
+  const deviceToken = reqCookie[COOKIE_NAME.DEVICE];
+  const { deviceId } = processDeviceToken(deviceToken, resHeaders);
 
   if (!csrfToken) {
     const { expiresAt, maxAge, token } = generateTokenParam(env);
-    resHeaders.setCookie('csrf', token, {
+    resHeaders.setCookie(COOKIE_NAME.CSRF, token, {
       secure: !import.meta.env.DEV,
       path: '/',
       expires: expiresAt,

--- a/server/lib/sessions.ts
+++ b/server/lib/sessions.ts
@@ -52,20 +52,13 @@ async function createAndSaveToken(
   const tokenParam = generateTokenParam(env);
   const { token, expiresAt } = tokenParam;
 
-  await db.batch([
-    db.insert(sessionsTable).values({
-      token,
-      expiresAt,
-      userId,
-      loginAttemptId,
-      deviceId,
-    }),
-    db.insert(userDevicesTable).values({
-      deviceId,
-      userId,
-      lastUsedAt: new Date(),
-    }),
-  ]);
+  await db.insert(sessionsTable).values({
+    token,
+    expiresAt,
+    userId,
+    loginAttemptId,
+    deviceId,
+  });
   setTokenCookie(env, resHeaders, tokenParam);
 }
 
@@ -123,7 +116,7 @@ const hasUserDevice = async (db: AppDatabase, deviceId: string, userId: string) 
 async function create(ctx: Context, user: { id: string; name: string; email: string }) {
   const { db, env, resHeaders, deviceId } = ctx;
   const loginAttempt = await saveLoginAttempt(ctx, true, user.id);
-  const loggedInBefore = hasUserDevice(db, deviceId, user.id);
+  const loggedInBefore = await hasUserDevice(db, deviceId, user.id);
   const { ip, city, country, userAgent } = loginAttempt;
   const alertEmail = signInAlertEmail(
     user.name,

--- a/server/lib/sessions.ts
+++ b/server/lib/sessions.ts
@@ -1,10 +1,10 @@
 import type { Context, ProtectedContext } from './trpc';
-import { and, eq, gt } from 'drizzle-orm';
+import { and, eq, gt, sql } from 'drizzle-orm';
 import { UAParser } from 'ua-parser-js';
-import type { AppDatabase } from './db';
+import { type AppDatabase } from './db';
 import type { CookieHeaders } from './CookieHeaders';
 import { differenceInMinutes, addMinutes, differenceInDays, addDays } from 'date-fns';
-import { loginAttemptsTable, sessionsTable, usersTable } from '../../db/schema';
+import { loginAttemptsTable, sessionsTable, userDevicesTable, usersTable } from '../../db/schema';
 import { signInAlertEmail } from './email';
 import { nanoid } from 'nanoid';
 import { millisecondsInDay, secondsInDay } from 'date-fns/constants';
@@ -82,8 +82,9 @@ async function saveLoginAttempt(ctx: Context, isSuccess: boolean, attemptedForId
   const ua = headers.get('user-agent') ?? '';
   const parsedUa = new UAParser(ua).getResult();
   const userAgent = `${parsedUa.browser.name} ${parsedUa.browser.version} / ${parsedUa.os.name} ${parsedUa.os.version}`;
-
-  const attempt: typeof loginAttemptsTable.$inferInsert = {
+  const id = nanoid();
+  const attempt: typeof loginAttemptsTable.$inferInsert & { id: string } = {
+    id,
     ip: headers.get('cf-connecting-ip') ?? '',
     userAgent,
     isSuccess,
@@ -99,17 +100,23 @@ async function saveLoginAttempt(ctx: Context, isSuccess: boolean, attemptedForId
     }
   }
 
-  const [{ id: loginAttemptId }] = await db
-    .insert(loginAttemptsTable)
-    .values(attempt)
-    .returning({ id: loginAttemptsTable.id });
+  await db.insert(loginAttemptsTable).values(attempt);
 
-  return { ...attempt, id: loginAttemptId };
+  return attempt;
 }
 
+const hasUserDevice = async (db: AppDatabase, deviceId: string, userId: string) =>
+  db
+    .select({ exist: sql<number>`1`.mapWith(Boolean) })
+    .from(userDevicesTable)
+    .where(and(eq(userDevicesTable.deviceId, deviceId), eq(userDevicesTable.userId, userId)))
+    .limit(1)
+    .then(([{ exist = false } = {}]) => exist);
+
 async function create(ctx: Context, user: { id: string; name: string; email: string }) {
-  const { db, env, resHeaders } = ctx;
+  const { db, env, resHeaders, deviceId } = ctx;
   const loginAttempt = await saveLoginAttempt(ctx, true, user.id);
+  const loggedInBefore = hasUserDevice(db, deviceId, user.id);
   const { ip, city, country, userAgent } = loginAttempt;
   const alertEmail = signInAlertEmail(
     user.name,
@@ -119,10 +126,15 @@ async function create(ctx: Context, user: { id: string; name: string; email: str
     userAgent ?? 'unknown',
   ).addRecipient(user.email, user.name);
 
-  await Promise.all([
-    createAndSaveToken(db, env, resHeaders, user.id, loginAttempt.id, ctx.deviceId),
-    alertEmail.send(ctx),
-  ]);
+  const promises: Promise<any>[] = [createAndSaveToken(db, env, resHeaders, user.id, loginAttempt.id, deviceId)];
+  if (!loggedInBefore) {
+    promises.push(alertEmail.send(ctx));
+    promises.push(
+      db.insert(userDevicesTable).values({ deviceId, userId: user.id, lastUsedAt: new Date() }).onConflictDoNothing(),
+    );
+  }
+
+  await Promise.all(promises);
 }
 
 async function revoke(ctx: ProtectedContext, otherSessionId?: string) {
@@ -211,7 +223,13 @@ async function check(
     .from(sessionsTable)
     .innerJoin(usersTable, eq(sessionsTable.userId, usersTable.id))
     .innerJoin(loginAttemptsTable, eq(sessionsTable.loginAttemptId, loginAttemptsTable.id))
-    .where(and(eq(sessionsTable.token, authToken), gt(sessionsTable.expiresAt, new Date())))
+    .where(
+      and(
+        eq(sessionsTable.token, authToken),
+        eq(sessionsTable.deviceId, deviceId),
+        gt(sessionsTable.expiresAt, new Date()),
+      ),
+    )
     .limit(1);
 
   if (!session) {

--- a/server/lib/sessions.ts
+++ b/server/lib/sessions.ts
@@ -3,7 +3,7 @@ import { and, eq, gt, sql } from 'drizzle-orm';
 import { UAParser } from 'ua-parser-js';
 import { type AppDatabase } from './db';
 import type { CookieHeaders } from './CookieHeaders';
-import { differenceInMinutes, addMinutes, differenceInDays, addDays } from 'date-fns';
+import { differenceInMinutes, addMinutes, differenceInDays, addDays, differenceInHours } from 'date-fns';
 import { loginAttemptsTable, sessionsTable, userDevicesTable, usersTable } from '../../db/schema';
 import { signInAlertEmail } from './email';
 import { nanoid } from 'nanoid';
@@ -52,13 +52,20 @@ async function createAndSaveToken(
   const tokenParam = generateTokenParam(env);
   const { token, expiresAt } = tokenParam;
 
-  await db.insert(sessionsTable).values({
-    token,
-    expiresAt,
-    userId,
-    loginAttemptId,
-    deviceId,
-  });
+  await db.batch([
+    db.insert(sessionsTable).values({
+      token,
+      expiresAt,
+      userId,
+      loginAttemptId,
+      deviceId,
+    }),
+    db.insert(userDevicesTable).values({
+      deviceId,
+      userId,
+      lastUsedAt: new Date(),
+    }),
+  ]);
   setTokenCookie(env, resHeaders, tokenParam);
 }
 
@@ -209,6 +216,7 @@ async function check(
       id: sessionsTable.id,
       createdAt: sessionsTable.createdAt,
       expiresAt: sessionsTable.expiresAt,
+      deviceLastUsed: userDevicesTable.lastUsedAt,
 
       user: {
         id: usersTable.id,
@@ -223,6 +231,10 @@ async function check(
     .from(sessionsTable)
     .innerJoin(usersTable, eq(sessionsTable.userId, usersTable.id))
     .innerJoin(loginAttemptsTable, eq(sessionsTable.loginAttemptId, loginAttemptsTable.id))
+    .innerJoin(
+      userDevicesTable,
+      and(eq(sessionsTable.deviceId, userDevicesTable.deviceId), eq(sessionsTable.userId, userDevicesTable.userId)),
+    )
     .where(
       and(
         eq(sessionsTable.token, authToken),
@@ -255,6 +267,14 @@ async function check(
   }
 
   const isAllowElevated = differenceInMinutes(new Date(), session.loginAttempt.timestamp) < 5;
+
+  // dont always update db, once every 4 hr is sufficient
+  if (differenceInHours(new Date(), session.deviceLastUsed) > 4) {
+    await db
+      .update(userDevicesTable)
+      .set({ lastUsedAt: new Date() })
+      .where(and(eq(userDevicesTable.deviceId, deviceId), eq(userDevicesTable.userId, userId)));
+  }
 
   return {
     deviceId,

--- a/server/lib/trpc.ts
+++ b/server/lib/trpc.ts
@@ -107,7 +107,6 @@ const t = initTRPC.context<Context>().create({
 export const router = t.router;
 export const publicProcedure = t.procedure.use(async opts => {
   const result = await opts.next();
-  console.log();
   if (!result.ok) {
     // result.error is TRPCError
     const { cause: innerCause, code, message } = result.error;


### PR DESCRIPTION
closes #33
closes #37
closes #35

- **feat: block navigation when expense form is dirty**
- **feat: remember expense list option while in expense pages**
- **feat: schema for user devices**
- **feat: never expiring device id on context initialization**
- **feat: setting not null deviceId for session & loginAttemptId**
- **feat: check userDevice before sending email alert**
- **feat: insert & update of user devices record**
- **feat: migration for user_devices and removing some useless session columns**
- **fix: new device signin alert not sent**
