### PR TITLE
Remove margin-inline-end for number input spinner

### DIFF
--- a/client/index.css
+++ b/client/index.css
@@ -94,3 +94,8 @@ input[type='number'].appearance-none::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+.input input[type='number']::-webkit-inner-spin-button,
+input.input[type='number']::-webkit-inner-spin-button {
+  margin-inline-end: 0;
+}


### PR DESCRIPTION
Force margin-inline-end to be 0, so that spinner isn't hidden

Regression for daisyui v5.6.0
